### PR TITLE
Render paragraph breaks (\n\n) during streaming, not only after

### DIFF
--- a/interfaces/web/static/ui-streaming.js
+++ b/interfaces/web/static/ui-streaming.js
@@ -32,10 +32,38 @@ const resetState = (para = null) => {
     pendingToolEvents = [];
 };
 
-// Update paragraph with markdown rendering
+// Update paragraph with markdown rendering.
+// Splits paraBuf on blank-line boundaries (\n\s*\n) so that \n\n in the stream
+// produces real <p> siblings in real time, matching the history render at
+// ui-parsing.js:renderContentText (which splits on /\n\s*\n/).
+// Before this fix, all streamed text accumulated into a single <p> with <br>
+// separators, so paragraph spacing only appeared after the post-stream history
+// swap in ui.js:finishStreaming.
 const updatePara = () => {
-    if (!state.curPara || !state.paraBuf) return;
-    state.curPara.innerHTML = processMarkdown(state.paraBuf);
+    if (!state.curPara) return;
+
+    // Process any paragraph boundaries that have arrived in the buffer.
+    // A boundary is \n followed by zero-or-more horizontal whitespace then \n.
+    let match;
+    while ((match = state.paraBuf.match(/\n[ \t]*\n/))) {
+        const before = state.paraBuf.slice(0, match.index);
+        const after = state.paraBuf.slice(match.index + match[0].length);
+
+        // Finalize the current paragraph with content before the break.
+        state.curPara.innerHTML = processMarkdown(before);
+
+        // Open a new paragraph for content after the break.
+        const newP = createElem('p');
+        streamMsg.el.appendChild(newP);
+        state.curPara = newP;
+        // Strip leading whitespace (including stray newlines from \n\n\n+ runs).
+        state.paraBuf = after.replace(/^\s+/, '');
+    }
+
+    // Render remaining buffer into the current paragraph.
+    if (state.paraBuf) {
+        state.curPara.innerHTML = processMarkdown(state.paraBuf);
+    }
 };
 
 // Create a tool accordion with loading state


### PR DESCRIPTION
### Problem

I noticed this when using Claude and Mistral, although all LLMs are likely affected. During streaming, `\n\n` in model output renders as a `<br>` inside a single `<p>`, so paragraph spacing doesn't appear until `finishStreaming` in `ui.js` swaps the message with a history-rendered version ~500ms after the stream ends. Visible as: paragraph gaps "pop in" at the end of every reply.

### Cause

`updatePara` in `interfaces/web/static/ui-streaming.js` accumulates all streamed text into `state.paraBuf` and writes `processMarkdown(paraBuf)` into a single `<p>`. The history render at `ui-parsing.js:renderContentText` splits on `/\n\s*\n/` to make real `<p>` siblings — streaming doesn't.

### Fix

Mirror the history render's split inside `updatePara`. On each update, scan `paraBuf` for blank-line boundaries; if found, finalize the current `<p>`, append a new one, and continue. Single newlines remain soft breaks. Runs of 3+ newlines collapse to one split. Trailing empty `<p>`s are cleaned up by the existing logic in `finishStreaming`. Tool / think / code accordion handling is untouched.

### Testing

Verified locally with Claude API and Mistral API. Also tested with a jsdom harness across: single-chunk multi-break, chunk-split-on-boundary, token-by-token streaming, 3+ newlines, whitespace-only blank lines, trailing breaks. All pass.